### PR TITLE
Fix issue where specified width and height in fromBlob did not resize the image

### DIFF
--- a/src/fromBlob.ts
+++ b/src/fromBlob.ts
@@ -34,7 +34,7 @@ const getHeightWidth = (
   const isHeightAuto = height === 'auto' || height === 0;
 
   if (!isWidthAuto && !isHeightAuto) {
-    return { width: img.naturalWidth, height: img.naturalHeight };
+    return { width, height };
   }
 
   if (!isWidthAuto) {


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `fromBlob` function where specifying the `width` and `height` parameters did not properly resize the image as intended.

## Changes
- Corrected the logic in the `getHeightWidth` function to handle cases where both `width` and `height` are specified.

Please review the changes and provide feedback🙇🏻‍♂️