### PR TITLE
chore(ts): modernize moduleResolution to Bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Switches the base tsconfig from the deprecated `moduleResolution: "Node"` (node10) to `"Bundler"`.

## Why
- `Node`/node10 resolution is deprecated and **hard-errors in TypeScript 6+**. This is the clean prerequisite for a future TS upgrade.
- `Bundler` matches how this ESM-first, tsup-built package is actually consumed (via the `exports` map), and aligns the base config with `tsconfig.test.json`, which already used `bundler`.

## TypeScript version decision (context)
Investigated upgrading TypeScript:
- **TS 7 is blocked** — no typescript-eslint release supports it (latest `8.65`, `rc-v8`, and `canary` all peer-cap at `typescript <6.1.0`), and tsup injects `baseUrl`/node10 options that TS 7 removes.
- **TS 6.0.3 works** but only as a transitional release requiring an `ignoreDeprecations: "6.0"` band-aid (for tsup's injected `baseUrl`) that itself stops working in TS 7.

Decision: **stay on TS 5.9**, keep only this Bundler modernization, and do a clean `5.9 -> 7` jump once typescript-eslint and tsup support TS 7. This PR carries no band-aid.

## Verified (all green, TS 5.9.3)
typecheck (both tsconfigs) · lint · build · size (2.99 kB / 3.23 kB) · publint · attw · 80 unit + 61 browser tests.